### PR TITLE
[BUGFIX] CleanWebpackPlugin only accepts an options object

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = (env, argv) => ({
   },
 
   plugins: [
-    new CleanWebpackPlugin(['dist']),
+    new CleanWebpackPlugin({cleanOnceBeforeBuildPatterns: ['dist']}),
     new VueLoaderPlugin(),
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, 'static', 'index.html'),


### PR DESCRIPTION
CleanWebpackPlugin needs a options object rather then just a Array of directories in the current version. 